### PR TITLE
Updating bindings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "ember-react",
+  "version": "0.1.1",
   "private": true,
   "devDependencies": {
     "loader": "stefanpenner/loader.js#1.0.0"

--- a/src/component.jsx
+++ b/src/component.jsx
@@ -70,16 +70,31 @@ var ReactComponent = Ember.Component.extend({
   },
 
   setUnknownProperty: function(key, value) {
-    var reactComponent = this._reactComponent;
     if(!this._props) {
       this._props = {};
     }
-    this._props[key] = value;
-    if(reactComponent) {
-      var props = {};
-      props[key] = value;
-      reactComponent.setProps(props);
+
+    var that = this;
+    var set = function(key, value) {
+      var reactComponent = that._reactComponent;
+      that._props[key] = value;
+      if(reactComponent) {
+        var props = {};
+        props[key] = value;
+        reactComponent.setProps(props);
+      }
+    };
+
+    if (key.match(/Binding$/)) {
+      var realKey = key.slice(0, -7);
+      value.subscribe(function() {
+        set(realKey, value.value());
+      });
+      set(realKey, value.value());
+    } else {
+      set(key, value);
     }
+
     return value;
   }
 


### PR DESCRIPTION
Hey,

So I pulled down ember-react to experiment in our ember application, and as of ember 1.11.3 at least the assumption that setUnknownProperty is called whenever a property changes doesn't seem to be valid. 

This is the diff that gave us updating values on our codebase, but I freely admit there may be cases I haven't thought of. I'm happy to tweak and fix as necessary!

Also, I'd love to open up a discussion about what to do about arrays or even just objects that have underlying parts of them mutated (like binding `person` to react, but then `person.set('name', 'Edward')`). Those changes do not seem to flow through, at the moment.

Cheers!
